### PR TITLE
Add keyboard shortcut to activate plugin

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,7 +22,7 @@
   "commands": {
         "_execute_browser_action": {
             "suggested_key": {
-                "default": "Alt+Shift+K"
+                "default": "Ctrl+Alt+c"
             }
         }
   },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,6 +19,13 @@
       "16": "images/kdeconnect-16.png"
     }
   },
+  "commands": {
+        "_execute_browser_action": {
+            "suggested_key": {
+                "default": "Alt+Shift+K"
+            }
+        }
+  },
   "options_ui": {
     "page": "options.html",
     "chrome_style": true


### PR DESCRIPTION
This should be useful when the user has chosen a default device, as sites can be sent without using the mouse.