### PR TITLE
Upgrade godbus dependency to v5.0.6

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,13 @@
-hash: 0c65b3581f4f0ed0f3c044adf385a0b4940c76ae4d628e797de54346e9eeb185
+hash: 6356daa1435b00b6aeabb357d17a7217fab61a3bd7ae7af9eb47c7ca0500b631
 updated: 2020-05-07T08:59:47.973819152+10:00
 imports:
 - name: github.com/buger/goterm
   version: cc3942e537b1ab00de92d348c40acbfa6565d20f
 - name: github.com/godbus/dbus
-  version: 37bf87eef99d69c4f1d3528bd66e3a87dc201472
+  version: daa017464e266380cdeb4e6f9613eba9182b59a3
   subpackages:
   - introspect
+  - v5
 - name: github.com/kardianos/osext
   version: c2c54e542fb797ad986b31721e1baedf214ca413
 - name: github.com/paulrademacher/climenu

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,8 +1,9 @@
 package: github.com/pdf/kdeconnect-chrome-extension
 import:
 - package: github.com/godbus/dbus
-  version: ^5.0.3
+  version: ^5.0.6
   subpackages:
   - introspect
+  - v5
 - package: github.com/paulrademacher/climenu
 - package: github.com/kardianos/osext


### PR DESCRIPTION
Updating godbus to v5 is a prerequisite for (haphazardly-done) [Windows support](https://user-images.githubusercontent.com/309008/139011338-69654dd6-105b-4943-80db-44b6bbb6b06d.png). I do not know this change breaks anything on Linux.

Without the v5 import change in dbus.go (which I think is [actually needed to use v5](https://github.com/godbus/dbus/commit/dda416a583d52c2e31913056ecb2e1b103350513)), go 1.17.2 on my Windows system builds kdeconnect-chrome-extension against v4,1 which is explicitly built without TCP transport support on Windows.

Unfortunately, glide doesn't handle the change well. If glide.lock needs to be generated from glide,yaml, `glide update` will fail with: `[ERROR] Error scanning github.com\godbus\dbus\v5: cannot find package "." in`. I do not know if this is simply because `glide` hasn't been maintained for years or, not knowing Go, I am missing something. Trying `github.com/godbus/dbus/v5` as the package name in glide.yaml doesn't help any.    
So I ended up making the changes by hand to glide.lock. glide.yaml has been updated for consistency's sake, though it's not used to actually generate glide.lock here. With glide.lock updated, `glide install` fetches v5 of godbus without any issues.

(I will mention that `glide install` fails to create something I can just then `go install` as per the instructions in the README; I have to run `go mod init && go mod vendor` after `glide install` and before `go build` will work.)

Thanks for the extension.